### PR TITLE
Fixes failed migration

### DIFF
--- a/migrations/2018_02_08_000001_smart_stats_drop_extra_nvme_columns.php
+++ b/migrations/2018_02_08_000001_smart_stats_drop_extra_nvme_columns.php
@@ -2,21 +2,18 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Capsule\Manager as Capsule;
-
 class SmartStatsDropExtraNvmeColumns extends Migration
 {
     private $tableName = 'smart_stats';
-
     public function up()
     {
         $capsule = new Capsule();
     
         $capsule::schema()->table($this->tableName, function (Blueprint $table) {
-            $table->dropColumn('temperature_nvme');
-            $table->dropColumn('power_on_hours_nvme');
-            $table->dropColumn('power_cycle_count_nvme');
+            $table->dropColumn(['temperature_nvme', 'power_on_hours_nvme', 'power_cycle_count_nvme']);
+        });
+        $capsule::schema()->table($this->tableName, function (Blueprint $table) {
             $table->renameColumn('Unused_Reserve_NAND_Blk', 'unused_reserve_nand_blk');
-         
         });
      }
     
@@ -28,7 +25,6 @@ class SmartStatsDropExtraNvmeColumns extends Migration
             $table->integer('power_on_hours_nvme')->nullable();
             $table->integer('power_cycle_count_nvme')->nullable();
             $table->renameColumn('unused_reserve_nand_blk', 'Unused_Reserve_NAND_Blk');
-            
         });
     }
-}
+}  


### PR DESCRIPTION
Combining the dropColumn commands and splitting the rename into separate capsule. Migration should now complete successfully.